### PR TITLE
Add CloudWatch Logs permissions to Lambda

### DIFF
--- a/2-lambda-template/template.yaml
+++ b/2-lambda-template/template.yaml
@@ -57,6 +57,13 @@ Resources:
             - elasticfilesystem:ClientWrite
             - elasticfilesystem:DescribeMountTargets
           Resource: "*"
+        - Sid: AWSLambdaBasicExecutionRole
+          Effect: Allow
+          Action:
+            - logs:CreateLogGroup
+            - logs:CreateLogStream
+            - logs:PutLogEvents
+          Resource: "*"
 
 Outputs:
   # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function


### PR DESCRIPTION
*Issue #, if available:* none

*Description of changes:* The current SAM template doesn't include permissions for Lambda to create and put logs, which prevents monitoring and debugging of the function. This commit adds CloudWatch Logs permissions to the Lambda function.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
