### PR TITLE
fix(largefiles): update the template.yml

### DIFF
--- a/3-largefiles/template.yaml
+++ b/3-largefiles/template.yaml
@@ -21,6 +21,15 @@ Parameters:
     Description: Access point ARN
 
 Resources:
+  LargeFilesLamdbaLayer:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+      ContentUri: files/
+      CompatibleRuntimes: 
+        - nodejs12.x
+        - nodejs8.10
+      LicenseInfo: 'MIT'
+      RetentionPolicy: Retain
   ProcessFileFunction:
     Type: AWS::Serverless::Function 
     Properties:
@@ -29,7 +38,8 @@ Resources:
       MemorySize: 2048      
       Handler: app.handler
       Layers: 
-        - arn:aws:lambda:us-east-1:780018668030:layer:ffmpeg:1
+        # - arn:aws:lambda:us-east-1:780018668030:layer:ffmpeg:1
+        - !Ref LargeFilesLamdbaLayer
       Environment:
         Variables:
           INPUT_FILE: !Ref InputFile


### PR DESCRIPTION
Update the template.yml  in large files example to use a dynamically created Lambda Layer resource 

fixes #7

*Issue #, if available:*
#7 

*Description of changes:*
The template.yml in large files example uses a hardcoded Lambda Layers reference. This needs to be replaced with a dynamically created resource (or instructions et al) 
[source](https://aws.amazon.com/blogs/compute/working-with-aws-lambda-and-lambda-layers-in-aws-sam/)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
